### PR TITLE
Game.marker visibility

### DIFF
--- a/js/client/Being.js
+++ b/js/client/Being.js
@@ -145,6 +145,7 @@ Being.prototype.pathfindingCallback = function(finalOrientation,action,delta,sen
     // path is an array of 2-tuples of coordinates
     if(path === null && this.isPlayer) {
         Game.moveTarget.visible = false;
+        Game.marker.visible = true;
     }else if(path !== null){
         if(action.action == 3 || action.action == 4){ // fight or chest
             finalOrientation = Game.computeFinalOrientation(path);


### PR DESCRIPTION
When clicking a location where the path finding algorithm returns null will causes Game.marker.visible to be set to false until the mouse has moved outside of the current cell. 