### PR TITLE
Update the documentation with suggested Tiled versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ The default por when using the Docker way is `80`, so you need to navigate to `<
 
 In `assets/maps/`, you can find `phaserquest_map.tmx`, which is the Tiled file of the map of the game, to be edited with the [Tiled Map Editor](http://www.mapeditor.org/). One you have made modifications in the Tiled file, you need to export it as a JSON file. But that file will contain a lot of layers, a legacy from how the original Browserquest map was designed. A lot of layers will translate to a very poor performance with Phaser, which is a shame since most of these layers contain only a few tiles. The solution is to "flatten" them to cram as many tiles as possible in the same layers. You can do so by running `formatMap()` from `js/server/format.js`. It will look for a `map.json` file in `assets/maps` and output two new files, the flattened map files for the client and the server.
 
+***Note:*** It is recommended to use _Tiled_ in version ***1.1.6*** or lower, which can be found here:
+
+- [https://github.com/bjorn/tiled/releases/tag/v1.1.6](https://github.com/bjorn/tiled/releases/tag/v1.1.6)
+- [https://sourceforge.net/projects/tiled/files/v1.1.6/](https://sourceforge.net/projects/tiled/files/v1.1.6/)
+
+Map JSON format has changed in _Tiled_ in higher versions. Cause of that provided `tmx` map won't be exported to JSON format supported by `format.js` script.
+
 ## Further documentation
 
 I have written and will keep writing articles about some development aspects of the game. The full list of existing articles is available [here](http://www.dynetisgames.com/tag/phaser-quest/).


### PR DESCRIPTION
---
Closes #19 

---

### How to test

The documentation includes information about _Tiled_ versions supported by `format.js` script.

### Potential regressions

None.