### PR TITLE
Add how to start documentation

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1,0 +1,50 @@
+### Running locally
+
+- provide web socket local url in `js/client/client.js`:
+
+```diff
+- Client.socket = io.connect();
++ Client.socket = io.connect('http://localhost:8081');
+```
+
+- run mongodb:
+
+```
+npm run start:db
+```
+
+- run server:
+
+```
+npm start
+```
+
+- run clinet:
+
+```
+npm run client:dev
+```
+
+### Edting the map
+
+- open `assets/maps/phaserquest_map.tmx` in Tiles-1.1.6
+- edit the map and export as json to `assets/maps/map.json`
+- format json map:
+
+```
+npm run map:format
+```
+
+### Running Docker
+
+Run:
+
+```
+npm run docker:build:run
+```
+
+To apply map changes once exported to `assets/maps/map.json`, run:
+
+```
+npm run docker:restart:map
+```

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Clone the repository. Inside the newly created directory, run `npm install` to i
 By default, it'll listen to connections on port `8081`; you can change that behaviour by using the `-p` flag (e.g. `node server.js -p 80`). 
 By default, it'll attempt to connect to MongoDB on port `27017`; you can change that behaviour by using the `--mongoPort` flag (e.g. `node server.js --mongoPort 25000`).
 
+[Here](GETTING_STARTED.md) you will find a step-by-step guide how to run and manage the application locally.
+
 ### Using Docker
 
 Alternatively, you can use the Dockerfile to create a container with all the necessary components already installed (thanks to Martin kramer for the corresponding pull request). You need to have [Docker](https://www.docker.com) installed. Then, in the directory where you clones the project, run:

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
     <div class="fontPreload">.</div> <!-- don't forget the dot, the div cannot be empty-->
     <div id='game'></div>
 </body>
-<script src="/socket.io/socket.io.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.3.0/socket.io.js"></script>
 <script src="js/client/phaser.js"></script>
 <script src="js/client/easystar.min.js"></script>
 <script src="js/client/phaser-input.min.js"></script>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,15 @@
   "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node server.js"
+    "start:db": "sudo mongod",
+    "start": "node server.js",
+    "client:dev": "http-server -p 80",
+    "docker:build:run": "bash scripts/docker-build-and-run.sh",
+    "docker:start": "docker-compose up -d",
+    "docker:restart:map": "bash scripts/docker-restart-map.sh",
+    "docker:build": "docker-compose build",
+    "docker:rebuild": "bash scripts/docker-rebuild.sh",
+    "map:format": "node -e 'require(\"./js/server/format\").format()'"
   },
   "repository": {
     "type": "git",

--- a/scripts/docker-build-and-run.sh
+++ b/scripts/docker-build-and-run.sh
@@ -1,0 +1,5 @@
+echo 'Building Docker...'
+docker-compose build
+docker-compose up -d
+open https://localhost
+echo 'Done.'

--- a/scripts/docker-rebuild.sh
+++ b/scripts/docker-rebuild.sh
@@ -1,0 +1,5 @@
+echo 'Rebuilding Docker...'
+docker-compose down
+docker-compose build
+docker-compose up -d
+echo 'Done.'

--- a/scripts/docker-restart-map.sh
+++ b/scripts/docker-restart-map.sh
@@ -1,0 +1,8 @@
+echo 'Applying map changes...'
+cd js/server
+node -e 'require("./format").format()'
+cd ../../
+docker-compose down
+docker-compose build
+docker-compose up -d
+echo 'Done.'


### PR DESCRIPTION
## Motivation

I spent some time trying to run the application locally. I would like to share my findings in the form of a documented process and utility scripts. Hopefully, it will help other developers.

Here are a couple of issues which are solved in the PR:

- missing `/socket.io/socket.io.js` file
- client socket not listening on the local server
- running `node server.js` does not start the whole application, just the server. The database and the client need to be run separately.

What is improved/added

- information on how to point the client to the local server
- a command for running the database, the server and the client
- a node command for the map formatting
- node and bash commands for faster Docker image management

## Alternative solution

I am open for discussion. Please share issues you face while running the application locally and how you deal with them.

## How to test

- Clone the repository and checkout the branch. It is important to have a clean environment
- The link in `README.md` file should move the user to `GETTING_STARTED.md` document
- Following instructions in the `GETTING_STARTED.md` file should be clear and help the user to run the application
- All new commands in `package.json` work

## Potential regressions

None
